### PR TITLE
Migrate from Puppeteer + Sparticuz Chromium to Playwright for Netlify Screenshots

### DIFF
--- a/nuxt-layer/netlify/functions/screenshots.ts
+++ b/nuxt-layer/netlify/functions/screenshots.ts
@@ -1,35 +1,26 @@
-import puppeteer from "puppeteer-core";
-import chrome from "@sparticuz/chromium";
+import { chromium } from "playwright";
 
 export default async function handler(event: any) {
-    console.log("🚀 Function started!");
+    console.log("🚀 Playwright function started!");
 
     try {
-        // 🔹 Hardcoded URL
-        const urlParam = "https://injective-blog.netlify.app";
-        console.log("🌍 Using Hardcoded URL:", urlParam);
-
+        const url = "https://injective-blog.netlify.app";
         const width = 1200;
         const height = 630;
-        const format = "jpeg"; // Supports jpeg, png, webp
+        const format = "jpeg";
 
-        console.log(
-            `📸 Generating screenshot for: ${urlParam} | ${width}x${height} | ${format}`
-        );
+        console.log(`🌍 Capturing screenshot for ${url}`);
 
-        // 🚀 Launch Puppeteer
-        const browser = await puppeteer.launch({
-            args: chrome.args,
-            executablePath: await chrome.executablePath(),
-            headless: chrome.headless,
+        // 🚀 Launch Playwright
+        const browser = await chromium.launch({
+            headless: true, // Fully headless
         });
 
-        console.log("✅ Puppeteer Launched!");
         const page = await browser.newPage();
-        await page.setViewport({ width, height });
+        await page.setViewportSize({ width, height });
 
-        console.log(`🔄 Navigating to ${urlParam}...`);
-        await page.goto(urlParam, { waitUntil: "domcontentloaded" });
+        console.log(`🔄 Navigating to ${url}...`);
+        await page.goto(url, { waitUntil: "domcontentloaded" });
 
         console.log("📷 Taking Screenshot...");
         const screenshot = await page.screenshot({ type: format });

--- a/nuxt-layer/netlify/functions/screenshots.ts
+++ b/nuxt-layer/netlify/functions/screenshots.ts
@@ -11,9 +11,8 @@ export default async function handler(event: any) {
 
         console.log(`🌍 Capturing screenshot for ${url}`);
 
-        // 🚀 Launch Playwright using `chromium.headless_shell`
         const browser = await chromium.launch({
-            executablePath: "/usr/bin/chromium", // Netlify’s Chromium location
+            executablePath: "/usr/bin/chromium",
             headless: true,
         });
 

--- a/nuxt-layer/netlify/functions/screenshots.ts
+++ b/nuxt-layer/netlify/functions/screenshots.ts
@@ -11,9 +11,10 @@ export default async function handler(event: any) {
 
         console.log(`🌍 Capturing screenshot for ${url}`);
 
-        // 🚀 Launch Playwright
+        // 🚀 Launch Playwright using `chromium.headless_shell`
         const browser = await chromium.launch({
-            headless: true, // Fully headless
+            executablePath: "/usr/bin/chromium", // Netlify’s Chromium location
+            headless: true,
         });
 
         const page = await browser.newPage();

--- a/nuxt-layer/package-lock.json
+++ b/nuxt-layer/package-lock.json
@@ -9,13 +9,12 @@
             "dependencies": {
                 "@nuxt/ui": "^3.0.0",
                 "@nuxtjs/sanity": "^1.13.3",
+                "@playwright/test": "^1.51.0",
                 "@portabletext/vue": "^1.0.12",
                 "@sanity/client": "^6.28.3",
                 "@sanity/image-url": "^1.1.0",
-                "@sparticuz/chromium": "^133.0.0",
                 "groq": "^3.79.0",
                 "nuxt": "^3.16.0",
-                "puppeteer-core": "^24.4.0",
                 "vue": "^3.5.13",
                 "vue-router": "^4.5.0",
                 "vue3-youtube": "^0.1.9"
@@ -2291,6 +2290,21 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@playwright/test": {
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.0.tgz",
+            "integrity": "sha512-dJ0dMbZeHhI+wb77+ljx/FeC8VBP6j/rj9OAojO08JI80wTZy6vRk9KvHKiDCUh4iMpEiseMgqRBIeW+eKX6RA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.51.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@polka/url": {
             "version": "1.0.0-next.28",
             "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
@@ -2382,27 +2396,6 @@
             },
             "peerDependencies": {
                 "vue": "^3.3.4"
-            }
-        },
-        "node_modules/@puppeteer/browsers": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.8.0.tgz",
-            "integrity": "sha512-yTwt2KWRmCQAfhvbCRjebaSX8pV1//I0Y3g+A7f/eS7gf0l4eRJoUCvcYdVtboeU4CTOZQuqYbZNS8aBYb8ROQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "debug": "^4.4.0",
-                "extract-zip": "^2.0.1",
-                "progress": "^2.0.3",
-                "proxy-agent": "^6.5.0",
-                "semver": "^7.7.1",
-                "tar-fs": "^3.0.8",
-                "yargs": "^17.7.2"
-            },
-            "bin": {
-                "browsers": "lib/cjs/main-cli.js"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/@redocly/ajv": {
@@ -3252,19 +3245,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@sparticuz/chromium": {
-            "version": "133.0.0",
-            "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-133.0.0.tgz",
-            "integrity": "sha512-wioNxMtSxRI+Y6ymc/UFPX9lY7A1SDgBezjFITH6arwe5CONfWosNDGpgflUGYajxxGktb1k3kjJ83jWzbccBw==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.9",
-                "tar-fs": "^3.0.8"
-            },
-            "engines": {
-                "node": ">= 16"
-            }
-        },
         "node_modules/@speed-highlight/core": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.7.tgz",
@@ -3592,12 +3572,6 @@
                 "vue": "^2.7.0 || ^3.0.0"
             }
         },
-        "node_modules/@tootallnate/quickjs-emscripten": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-            "license": "MIT"
-        },
         "node_modules/@trysound/sax": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -3726,16 +3700,6 @@
             "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
             "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
             "license": "MIT"
-        },
-        "node_modules/@types/yauzl": {
-            "version": "2.10.3",
-            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-            "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/youtube": {
             "version": "0.0.39",
@@ -4375,18 +4339,6 @@
                 "url": "https://github.com/sponsors/sxzz"
             }
         },
-        "node_modules/ast-types": {
-            "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/ast-walker-scope": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.6.2.tgz",
@@ -4468,63 +4420,6 @@
             "license": "Apache-2.0",
             "optional": true
         },
-        "node_modules/bare-fs": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.1.tgz",
-            "integrity": "sha512-ilQs4fm/l9eMfWY2dY0WCIUplSUp7U0CT1vrqMg1MUdeZl4fypu5UP0XcDBK5WBQPJAKP1b7XEodISmekH/CEg==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "bare-events": "^2.0.0",
-                "bare-path": "^3.0.0",
-                "bare-stream": "^2.0.0"
-            },
-            "engines": {
-                "bare": ">=1.7.0"
-            }
-        },
-        "node_modules/bare-os": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.0.tgz",
-            "integrity": "sha512-BUrFS5TqSBdA0LwHop4OjPJwisqxGy6JsWVqV6qaFoe965qqtaKfDzHY5T2YA1gUL0ZeeQeA+4BBc1FJTcHiPw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "engines": {
-                "bare": ">=1.14.0"
-            }
-        },
-        "node_modules/bare-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-            "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "bare-os": "^3.0.1"
-            }
-        },
-        "node_modules/bare-stream": {
-            "version": "2.6.5",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
-            "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "streamx": "^2.21.0"
-            },
-            "peerDependencies": {
-                "bare-buffer": "*",
-                "bare-events": "*"
-            },
-            "peerDependenciesMeta": {
-                "bare-buffer": {
-                    "optional": true
-                },
-                "bare-events": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4544,15 +4439,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/basic-ftp": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            }
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
@@ -4863,19 +4749,6 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/chromium-bidi": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-2.1.2.tgz",
-            "integrity": "sha512-vtRWBK2uImo5/W2oG6/cDkkHSm+2t6VHgnj+Rcwhb0pP74OoUb4GipyRX/T/y39gYQPhioP0DPShn+A7P6CHNw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "mitt": "^3.0.1",
-                "zod": "^3.24.1"
-            },
-            "peerDependencies": {
-                "devtools-protocol": "*"
             }
         },
         "node_modules/citty": {
@@ -5541,15 +5414,6 @@
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "license": "MIT"
         },
-        "node_modules/data-uri-to-buffer": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/debug": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -5634,20 +5498,6 @@
             "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
             "license": "MIT"
         },
-        "node_modules/degenerator": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-            "license": "MIT",
-            "dependencies": {
-                "ast-types": "^0.13.4",
-                "escodegen": "^2.1.0",
-                "esprima": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/denque": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -5696,12 +5546,6 @@
             "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.1.1.tgz",
             "integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==",
             "license": "MIT"
-        },
-        "node_modules/devtools-protocol": {
-            "version": "0.0.1413902",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1413902.tgz",
-            "integrity": "sha512-yRtvFD8Oyk7C9Os3GmnFZLu53yAfsnyw1s+mLmHHUK0GQEc9zthHWvS1r67Zqzm5t7v56PILHIVZ7kmFMaL2yQ==",
-            "license": "BSD-3-Clause"
         },
         "node_modules/dfa": {
             "version": "1.2.0",
@@ -5932,15 +5776,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "license": "MIT",
-            "dependencies": {
-                "once": "^1.4.0"
-            }
-        },
         "node_modules/enhanced-resolve": {
             "version": "5.18.1",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
@@ -6054,59 +5889,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/escodegen": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "esprima": "^4.0.1",
-                "estraverse": "^5.2.0",
-                "esutils": "^2.0.2"
-            },
-            "bin": {
-                "escodegen": "bin/escodegen.js",
-                "esgenerate": "bin/esgenerate.js"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "optionalDependencies": {
-                "source-map": "~0.6.1"
-            }
-        },
-        "node_modules/escodegen/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "license": "BSD-2-Clause",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/estree-walker": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -6114,15 +5896,6 @@
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/etag": {
@@ -6217,41 +5990,6 @@
             "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
             "license": "MIT"
         },
-        "node_modules/extract-zip": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "debug": "^4.1.1",
-                "get-stream": "^5.1.0",
-                "yauzl": "^2.10.0"
-            },
-            "bin": {
-                "extract-zip": "cli.js"
-            },
-            "engines": {
-                "node": ">= 10.17.0"
-            },
-            "optionalDependencies": {
-                "@types/yauzl": "^2.9.1"
-            }
-        },
-        "node_modules/extract-zip/node_modules/get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "license": "MIT",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6296,15 +6034,6 @@
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/fd-slicer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-            "license": "MIT",
-            "dependencies": {
-                "pend": "~1.2.0"
             }
         },
         "node_modules/fdir": {
@@ -6615,20 +6344,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/get-uri": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-            "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
-            "license": "MIT",
-            "dependencies": {
-                "basic-ftp": "^5.0.2",
-                "data-uri-to-buffer": "^6.0.2",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/get-youtube-id": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-youtube-id/-/get-youtube-id-1.0.1.tgz",
@@ -6895,19 +6610,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/http-shutdown": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/http-shutdown/-/http-shutdown-1.2.2.tgz",
@@ -7043,19 +6745,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/ioredis"
-            }
-        },
-        "node_modules/ip-address": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-            "license": "MIT",
-            "dependencies": {
-                "jsbn": "1.1.0",
-                "sprintf-js": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 12"
             }
         },
         "node_modules/iron-webcrypto": {
@@ -7414,12 +7103,6 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
-        },
-        "node_modules/jsbn": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-            "license": "MIT"
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
@@ -8223,15 +7906,6 @@
             "integrity": "sha512-9ca1h0Xjvo9bEkE4UOxgAzLV0jHKe6LMaxo37ND2DAhhAtd0j8pR1Wxz+/goMrZO8AEZTWCmyaOsFI/W5AdpCQ==",
             "license": "MIT"
         },
-        "node_modules/netmask": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/nitropack": {
             "version": "2.11.6",
             "resolved": "https://registry.npmjs.org/nitropack/-/nitropack-2.11.6.tgz",
@@ -8668,15 +8342,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
         "node_modules/onetime": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -8781,38 +8446,6 @@
                 "@oxc-parser/binding-wasm32-wasi": "0.56.5",
                 "@oxc-parser/binding-win32-arm64-msvc": "0.56.5",
                 "@oxc-parser/binding-win32-x64-msvc": "0.56.5"
-            }
-        },
-        "node_modules/pac-proxy-agent": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-            "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-            "license": "MIT",
-            "dependencies": {
-                "@tootallnate/quickjs-emscripten": "^0.23.0",
-                "agent-base": "^7.1.2",
-                "debug": "^4.3.4",
-                "get-uri": "^6.0.1",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.6",
-                "pac-resolver": "^7.0.1",
-                "socks-proxy-agent": "^8.0.5"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/pac-resolver": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-            "license": "MIT",
-            "dependencies": {
-                "degenerator": "^5.0.0",
-                "netmask": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/package-json-from-dist": {
@@ -8988,12 +8621,6 @@
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "license": "MIT"
         },
-        "node_modules/pend": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-            "license": "MIT"
-        },
         "node_modules/perfect-debounce": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -9034,6 +8661,50 @@
             "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.1.tgz",
             "integrity": "sha512-hkT3yDPFbs95mNCy1+7qNKC6Pro+/ibzYxtM2iqEigpf0sVw+bg4Zh9/snjsBcf990vfIsg5+1U7VyiyBb3etg==",
             "license": "MIT"
+        },
+        "node_modules/playwright": {
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0.tgz",
+            "integrity": "sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.51.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
+            "integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==",
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
         },
         "node_modules/pluralize": {
             "version": "8.0.0",
@@ -9637,15 +9308,6 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "license": "MIT"
         },
-        "node_modules/progress": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/progress-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
@@ -9687,67 +9349,6 @@
             "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
             "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
             "license": "MIT"
-        },
-        "node_modules/proxy-agent": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-            "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "^4.3.4",
-                "http-proxy-agent": "^7.0.1",
-                "https-proxy-agent": "^7.0.6",
-                "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "^7.1.0",
-                "proxy-from-env": "^1.1.0",
-                "socks-proxy-agent": "^8.0.5"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/proxy-agent/node_modules/lru-cache": {
-            "version": "7.18.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
-        },
-        "node_modules/pump": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-            "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
-            "license": "MIT",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
-        "node_modules/puppeteer-core": {
-            "version": "24.4.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.4.0.tgz",
-            "integrity": "sha512-eFw66gCnWo0X8Hyf9KxxJtms7a61NJVMiSaWfItsFPzFBsjsWdmcNlBdsA1WVwln6neoHhsG+uTVesKmTREn/g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@puppeteer/browsers": "2.8.0",
-                "chromium-bidi": "2.1.2",
-                "debug": "^4.4.0",
-                "devtools-protocol": "0.0.1413902",
-                "typed-query-selector": "^2.12.0",
-                "ws": "^8.18.1"
-            },
-            "engines": {
-                "node": ">=18"
-            }
         },
         "node_modules/quansync": {
             "version": "0.2.8",
@@ -10485,49 +10086,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/smart-buffer": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
         "node_modules/smob": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
             "integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
             "license": "MIT"
-        },
-        "node_modules/socks": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-            "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
-            "license": "MIT",
-            "dependencies": {
-                "ip-address": "^9.0.5",
-                "smart-buffer": "^4.2.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/socks-proxy-agent": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "^4.3.4",
-                "socks": "^2.8.3"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
         },
         "node_modules/source-map": {
             "version": "0.7.4",
@@ -10590,12 +10153,6 @@
             "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
             "integrity": "sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw==",
             "license": "MIT"
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "license": "BSD-3-Clause"
         },
         "node_modules/standard-as-callback": {
             "version": "2.1.0",
@@ -11042,20 +10599,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/tar-fs": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-            "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
-            "license": "MIT",
-            "dependencies": {
-                "pump": "^3.0.0",
-                "tar-stream": "^3.1.5"
-            },
-            "optionalDependencies": {
-                "bare-fs": "^4.0.1",
-                "bare-path": "^3.0.0"
-            }
-        },
         "node_modules/tar-stream": {
             "version": "3.1.7",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
@@ -11253,12 +10796,6 @@
             "version": "0.1.17",
             "resolved": "https://registry.npmjs.org/type-level-regexp/-/type-level-regexp-0.1.17.tgz",
             "integrity": "sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==",
-            "license": "MIT"
-        },
-        "node_modules/typed-query-selector": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-            "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
             "license": "MIT"
         },
         "node_modules/typescript": {
@@ -12491,12 +12028,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "license": "ISC"
-        },
         "node_modules/ws": {
             "version": "8.18.1",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
@@ -12638,25 +12169,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/yauzl": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-            "license": "MIT",
-            "dependencies": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.1.0"
-            }
-        },
-        "node_modules/yauzl/node_modules/buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/yoctocolors": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
@@ -12709,15 +12221,6 @@
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/zod": {
-            "version": "3.24.2",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-            "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/nuxt-layer/package.json
+++ b/nuxt-layer/package.json
@@ -12,13 +12,12 @@
     "dependencies": {
         "@nuxt/ui": "^3.0.0",
         "@nuxtjs/sanity": "^1.13.3",
+        "@playwright/test": "^1.51.0",
         "@portabletext/vue": "^1.0.12",
         "@sanity/client": "^6.28.3",
         "@sanity/image-url": "^1.1.0",
-        "@sparticuz/chromium": "^133.0.0",
         "groq": "^3.79.0",
         "nuxt": "^3.16.0",
-        "puppeteer-core": "^24.4.0",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0",
         "vue3-youtube": "^0.1.9"


### PR DESCRIPTION
This PR replaces Puppeteer (puppeteer-core) and Sparticuz Chromium (@sparticuz/chromium) with Playwright (@playwright/test) for generating screenshots in our Netlify function.

### What changed?

- Removed:
```json
"@sparticuz/chromium": "^133.0.0",
"puppeteer-core": "^24.4.0"
```
- Added:
```json
"@playwright/test": "^1.45.2"
```
- Updated `netlify/functions/screenshots.ts` to use Playwright’s built-in Chromium instead of Sparticuz Chromium.
- Modified the function to launch Playwright using Netlify’s built-in headless Chromium (`chromium.headless_shell`) instead of requiring an external binary.

### Why This Change?

#### Lighter Install & Faster Deployments

- No need for external Chromium downloads (@sparticuz/chromium).
- Netlify’s runtime already includes a compatible Chromium version.
- Reduces package size and speeds up Netlify builds.

#### More Reliable in Serverless Environments

- Playwright natively supports headless execution with minimal overhead.
- Avoids the frequent compatibility issues that occur with Puppeteer in Netlify Functions.

#### Better Performance & Cold Start Reduction

- Playwright optimizes browser launches for serverless functions.
- No need to manually define a Chromium executable path.